### PR TITLE
Fix Swift 3.1 warning

### DIFF
--- a/PXGoogleDirections/PXGoogleDirectionsRouteFare.swift
+++ b/PXGoogleDirections/PXGoogleDirectionsRouteFare.swift
@@ -18,6 +18,6 @@ public struct PXGoogleDirectionsRouteFare {
 
 extension PXGoogleDirectionsRouteFare: CustomStringConvertible {
 	public var description: String {
-		return "\(currency) \(value)"
+		return "\(currency ?? "") \(value ?? 0)"
 	}
 }


### PR DESCRIPTION
This change is backwards-compatible fix for new Swift 3.1 warning.